### PR TITLE
Redis 캐시 적용과 App <-> Api 간 분당 통신 제한 (Throttling) 기능 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,3 +83,9 @@
 ✅ docker image 만들기
 ✅ docker image push
 ✅ deployment yaml 추가 및 적용
+
+---
+
+#### 6-1) redis setUp
+✅ local redis setUp
+✅ Spring Application에 redis 연동

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,3 +89,6 @@
 #### 6-1) redis setUp
 ✅ local redis setUp
 ✅ Spring Application에 redis 연동
+
+####  6-2) threshold 기능 적용
+✅ threshold, throttling(알고리즘: token bucket) 기능 적용

--- a/build.gradle
+++ b/build.gradle
@@ -24,15 +24,19 @@ repositories {
 }
 
 dependencies {
-    //starter
+    //web - starter
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    //security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
@@ -46,8 +50,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    //database
+    //database + jpa
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     //test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    //throttling
+    implementation 'com.bucket4j:bucket4j-core:8.7.0'
+
     //security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'

--- a/redis.md
+++ b/redis.md
@@ -1,0 +1,16 @@
+## REDIS local 구축
+
+1. 이미지 다운로드
+
+- docker pull redis
+
+2. 실행
+
+- docker run -p 6379:6379 --name redis
+- docker ps -a(별개의 창)
+
+3. 컨테이너 접속
+- docker exec -it {container id} /bin/bash
+
+4. redis 서버 접속
+- redis-cli

--- a/src/main/java/fastcampus/auth/AuthApplication.java
+++ b/src/main/java/fastcampus/auth/AuthApplication.java
@@ -2,8 +2,10 @@ package fastcampus.auth;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class AuthApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/fastcampus/auth/config/CustomRateLimiter.java
+++ b/src/main/java/fastcampus/auth/config/CustomRateLimiter.java
@@ -1,0 +1,42 @@
+package fastcampus.auth.config;
+
+import fastcampus.auth.repository.AppRoleRepository;
+import io.github.bucket4j.BandwidthBuilder;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.local.LocalBucket;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class CustomRateLimiter {
+
+    private final Map<String, Bucket> keyToBucketMap = new ConcurrentHashMap<>();
+    private final Duration REFILL_PERIOD_ONE_MINUTE = Duration.ofMinutes(1L);
+
+    private final AppRoleRepository appRoleRepository;
+
+    public boolean tryConsume(Long appId, Long apiId){
+        String key = appId.toString() + ":" + apiId.toString();
+        Bucket bucket = keyToBucketMap.computeIfAbsent(key, k -> createBucket(appId, apiId));
+
+        log.info(String.format("throttling: %s count ++1", key));
+        return bucket.tryConsume(1);
+    }
+
+    public LocalBucket createBucket(Long appId, Long apiId){
+        Integer threshold = appRoleRepository.findByAppIdAndApiId(appId, apiId).getThreshold();
+        return Bucket.builder()
+                .addLimit(
+                        BandwidthBuilder.builder()
+                                .capacity(threshold)
+                                .refillIntervally(threshold, REFILL_PERIOD_ONE_MINUTE).build()
+                ).build();
+    }
+
+}

--- a/src/main/java/fastcampus/auth/config/RedisConfig.java
+++ b/src/main/java/fastcampus/auth/config/RedisConfig.java
@@ -1,0 +1,46 @@
+package fastcampus.auth.config;
+
+import java.time.Duration;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    // 커넥션 팩토리를 빈으로 등록 (Connection으로 Lettuce 사용)
+    @Bean
+    public LettuceConnectionFactory connectionFactory(){
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(){
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory());
+        return template;
+    }
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory factory){
+        RedisCacheConfiguration cacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofMinutes(1L));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(factory)
+                .cacheDefaults(cacheConfiguration)
+                .build();
+    }
+
+
+}

--- a/src/main/java/fastcampus/auth/controller/EmployeeController.java
+++ b/src/main/java/fastcampus/auth/controller/EmployeeController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,4 +34,13 @@ public class EmployeeController {
         Employee newEmployee = employeeService.createEmployee(firstName, lastName, departmentId, kakaoNickName);
         return new ResponseEntity<>(newEmployee, HttpStatus.CREATED);
     }
+
+    /**
+     * Cache를 이용한 단건 조회 테스트를 위한 테스트 API
+     */
+    @GetMapping(value = "/employees/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Employee> findById(@PathVariable Long id) {
+        return ResponseEntity.ok().body(employeeService.findEmployeeById(id));
+    }
+
 }

--- a/src/main/java/fastcampus/auth/model/AppRole.java
+++ b/src/main/java/fastcampus/auth/model/AppRole.java
@@ -1,6 +1,7 @@
 package fastcampus.auth.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -21,5 +22,10 @@ public class AppRole {
     @OneToOne
     @JoinColumn(name="api_id", referencedColumnName = "id")
     private Api api;
+
+    @Column(name = "app_id")
+    private Long appId;
+
+    private Integer threshold;
 
 }

--- a/src/main/java/fastcampus/auth/model/Employee.java
+++ b/src/main/java/fastcampus/auth/model/Employee.java
@@ -1,5 +1,6 @@
 package fastcampus.auth.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -48,6 +49,7 @@ public class Employee {
 
     private String kakaoNickName;
 
+    @JsonIgnore
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(
             name = "employee_role_mapping",

--- a/src/main/java/fastcampus/auth/repository/AppRoleRepository.java
+++ b/src/main/java/fastcampus/auth/repository/AppRoleRepository.java
@@ -1,0 +1,9 @@
+package fastcampus.auth.repository;
+
+import fastcampus.auth.model.AppRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AppRoleRepository extends JpaRepository<AppRole, Long> {
+
+    AppRole findByAppIdAndApiId(Long appId, Long apiId);
+}

--- a/src/main/java/fastcampus/auth/service/EmployeeService.java
+++ b/src/main/java/fastcampus/auth/service/EmployeeService.java
@@ -3,8 +3,10 @@ package fastcampus.auth.service;
 import fastcampus.auth.model.Employee;
 import fastcampus.auth.repository.EmployeeRepository;
 import java.util.List;
+import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -30,5 +32,12 @@ public class EmployeeService {
 
         Employee employee = Employee.createEmployee(firstName, lastName, departmentId, kakaoNickName,null);
         return employeeRepository.save(employee);
+    }
+
+    // @Cacheable -> 없으면 캐시에 적재, 없으면 TTL update
+    @Cacheable(cacheNames = "employee", key = "#id")
+    public Employee findEmployeeById(Long id) {
+        log.info("Cache miss for employee with id {}", id);  // 캐시 미스일 때 로그 출력
+        return employeeRepository.findById(id).orElseThrow(() -> new NoSuchElementException("id를 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/fastcampus/auth/service/TokenService.java
+++ b/src/main/java/fastcampus/auth/service/TokenService.java
@@ -1,5 +1,6 @@
 package fastcampus.auth.service;
 
+import fastcampus.auth.config.CustomRateLimiter;
 import fastcampus.auth.dto.AppTokenResponseDto;
 import fastcampus.auth.dto.ValidateTokenDto;
 import fastcampus.auth.model.Api;
@@ -8,15 +9,19 @@ import fastcampus.auth.repository.ApiRepository;
 import fastcampus.auth.repository.AppRepository;
 import fastcampus.auth.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class TokenService {
 
     private final AppRepository appRepository;
     private final ApiRepository apiRepository;
+    private final CustomRateLimiter customRateLimiter;
 
     public AppTokenResponseDto createAppToken(Long appId){
         App app = appRepository.getById(appId);
@@ -29,6 +34,15 @@ public class TokenService {
 
     public ResponseEntity<String> validateToken(ValidateTokenDto dto) {
         Api api = apiRepository.findByMethodAndPath(dto.getMethod(), dto.getPath());
-        return JwtUtil.validateAppToken(dto, api);
+        ResponseEntity<String> resp = JwtUtil.validateAppToken(dto, api);
+
+        if(resp.getStatusCode().is2xxSuccessful()){
+            Long appId = Long.valueOf(JwtUtil.parseSubject(dto.getToken()));
+            if(!customRateLimiter.tryConsume(appId, api.getId())){
+                log.error("Too many requests");
+                return new ResponseEntity<>("too many requests", HttpStatus.TOO_MANY_REQUESTS);
+            }
+        }
+        return resp;
     }
 }

--- a/src/main/java/fastcampus/auth/util/JwtUtil.java
+++ b/src/main/java/fastcampus/auth/util/JwtUtil.java
@@ -75,6 +75,11 @@ public class JwtUtil {
                 .getBody();
     }
 
+    public static String parseSubject(String token){
+        return parseToken(token).getSubject();
+    }
+
+
     public static ResponseEntity<String> validateAppToken(ValidateTokenDto dto, Api api) {
         Claims claims;
         try {

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -12,6 +12,10 @@ spring.datasource.url = jdbc:mysql://localhost:3306/${SQL_DB_NAME}?useUnicode=tr
 spring.datasource.username = ${SQL_USER_NAME}
 spring.datasource.password = ${SQL_PASSWORD}
 
+# redis cache
+spring.data.redis.host= localhost
+spring.data.redis.port= 6379
+
 
 kakao.client_id: ${REST_API_KEY}
 kakao.redirect_uri: ${REDIRECT_URI}


### PR DESCRIPTION
Token Bucket 알고리즘을 이용한 스로틀링 제한 기능 추가

ex) App 1번은 Api 5번 기능을 1(분)당 3회 요청 가능
ex) App 2번은 Api 1번 기능을 1(분)당 10회 요청 가능

초과 요청 시 HttpStatus.403 (Too Many Requests) 에러 발생

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved performance with enhanced caching mechanisms.
  - Introduced API rate limiting to help safeguard service endpoints.
  - Integrated Redis for efficient data caching and faster responses.
  - Added a new endpoint for retrieving employee records with optimized performance.

- **Documentation**
  - Provided updated instructions for setting up a local Redis environment using Docker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->